### PR TITLE
incompatible version of hilt and kotlin ext vers.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.6.20'
     ext.hilt_version = '2.40.1'
     repositories {
         google()


### PR DESCRIPTION
this old base version of kotlin ext (1.7.20) makes hilt apps crash when im trying to run this codelab : https://developer.android.com/codelabs/android-hilt#6.  i got this error : error: [Hilt] Unsupported metadata version. Check that your Kotlin version is >= 1.0: java.lang.IllegalStateException: Unsupported metadata version. Check that your Kotlin version is >= 1.0 at

And then i try to the solution code, to check if everythings fine, and it does. but the kotlin extension version in this file is not the same like the solution. Thus, makes the app crash.